### PR TITLE
Fix case where app breaks

### DIFF
--- a/CoronaStats.rb
+++ b/CoronaStats.rb
@@ -16,6 +16,11 @@ module Corona
 			if country == 'uk'
 				country = 'UK'
 			end
+
+			if @countries_stats[country].nil?
+				return "Nothing found!"
+			end
+			
 			@countries_stats[country].each do |key, value|
 				if country == 'USA'
 					ret_string << "#{key}: #{value}\n"


### PR DESCRIPTION
When trying to search for "/Vatican City" app breaks. This just checks that app doesn't try to loop over nil value and returns message to the bot.